### PR TITLE
fix: add JAVA_HOME environment variable to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ENV WAIT_FOR_TIMEOUT=30
 ENV TZ=UTC
 ENV DEBUG=false
 ENV JAVA_OPTS=""
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV JMX_PROMETHEUS=false
 ENV JMX_PROMETHEUS_CONF=/operaton/javaagent/prometheus-jmx.yml
 ENV JMX_PROMETHEUS_PORT=9404


### PR DESCRIPTION
**Description**
This PR adds the JAVA_HOME environment variable to the Dockerfile, explicitly setting it to /usr/lib/jvm/java-17-openjdk. This resolves the warning message during container startup:

By setting JAVA_HOME in the Dockerfile, we ensure that the correct Java installation path is available to the application and any tools or scripts that rely on this variable.

**Type of Change**
- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

**Checklist**  
- [x] I have tested my changes  
- [ ] I have added/updated documentation (if needed)  
- [x] I have linked the related issue (if applicable)  
- [x] I have followed the code style of the project 

**Screenshots (if applicable)**

Before the fix:

```
JAVA_HOME is not set. Unexpected results may occur.
Set JAVA_HOME to the directory of your local JDK to avoid this message.
Java version is 17.0.12
REST API enabled
WebApps enabled
...
```

After the fix:

```
Java version is 17.0.12
REST API enabled
WebApps enabled
...
```