### PR TITLE
fix: Avoid tagging pre-releases as `latest`

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -54,7 +54,11 @@ if [ "${SNAPSHOT}" = "true" ]; then
     tags+=("SNAPSHOT")
 else
     tags+=("${VERSION}")
-    tags+=("latest")
+    # Only add "latest" tag if VERSION matches semantic versioning pattern `major.minor.patch`
+    # In other words, avoid tagging pre-releases with suffixes like -M1
+    if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        tags+=("latest")
+    fi
 fi
 
 build_and_push "${tags[@]}"


### PR DESCRIPTION
This change checks the given `VERSION` if it strictly matches the semantic versioning pattern without suffixes. Only for these releases the `latest` tag is applied.

fixes #34